### PR TITLE
.movie__summary에 말줄임표(ellipsis) 적용

### DIFF
--- a/src/Movie.css
+++ b/src/Movie.css
@@ -45,3 +45,14 @@
     margin-right: 10px;
     font-size: 14px;
 }
+
+.movie__summary {
+    display: -webkit-box;
+    text-overflow: ellipsis;
+    -webkit-line-clamp: 6;
+    -webkit-box-orient: vertical;
+    word-wrap: break-word;
+    overflow: hidden;
+    line-height: 1.2em;
+    height: 7.2em;
+}

--- a/src/Movie.tsx
+++ b/src/Movie.tsx
@@ -20,7 +20,7 @@ export default function Movie({ id, year, title, summary, poster, genres }: Movi
                 <ul className="movie__genres">
                     {genres.map((genre, index) => (<li key={index} className="genres__genre">{genre}</li>))}
                 </ul>
-                <p className="movie__summary">{summary.slice(0, 140)}...</p>
+                <p className="movie__summary">{summary}</p>
             </div>
         </div>
     )


### PR DESCRIPTION
- Firefox에서 말줄임표가 동작하지 않는 문제를 해결하기 위해 height 값 7.2em(1.2em * 6) 지정